### PR TITLE
Render newlines correctly in DDoc comments

### DIFF
--- a/lumen/lumen.cpp
+++ b/lumen/lumen.cpp
@@ -107,7 +107,7 @@ void LumenPluginView::getTextHint(const Cursor& cursor, QString& text)
     int offset = utf8.length();
     utf8.append(document->text(rangece, false).toUtf8());
 
-    text = m_plugin->dcd()->doc(utf8, offset).trimmed();
+    text = m_plugin->dcd()->doc(utf8, offset).trimmed().replace("\\n", "\n");
 }
 
 LumenPluginView::~LumenPluginView()


### PR DESCRIPTION
Prior to this change, newlines in DDoc comments rendered as "\n" (that is the backslash and the n both being displayed).  This change attempts to fix it so instead of a backslash and an n, we get an actual newline.
